### PR TITLE
fix: make image zoom respect theme settings

### DIFF
--- a/modules/base.php
+++ b/modules/base.php
@@ -138,6 +138,12 @@ class heraBass
 
     function panther_image_zoom($content)
     {
+        global $heraSetting;
+        // Check if image zoom is enabled in settings
+        if (!$heraSetting->get_setting('image_zoom')) {
+            return $content;
+        }
+        
         $pattern = "/<a(.*?)href=('|\")([^>]*).(bmp|gif|jpeg|jpg|png)('|\")(.*?)>(.*?)<\/a>/i";
         $replacement = '<a$1href=$2$3.$4$5 data-action="imageZoomIn" $6>$7</a>';
         $content = preg_replace($pattern, $replacement, $content);


### PR DESCRIPTION

## Problem
There's a setting to toggle image zoom/lightbox functionality(图片灯箱), but this setting was not being respected. The lightbox was always enabled regardless of the setting's value.

## Changes
- Added check for `$heraSetting->get_setting('image_zoom')` before applying lightbox attributes.
- If setting is disabled, content is returned unmodified

## Testing
1. Go to Theme Settings > Singular Settings
2. Toggle "Post image zoom" setting
3. Verify lightbox only works when setting is enabled. 